### PR TITLE
Support debug logging

### DIFF
--- a/detail/Configuration.js
+++ b/detail/Configuration.js
@@ -51,6 +51,7 @@ function defaultConfiguration() {
 	  maxAllowedSetImmediateBatchSize: 500,
 	  fakeNodeDedicatedTimers: true,
 	  rejectOnCallbackFailure: false,
+    debugLogger: function(message) {},
     timerExpirationPolicy: "FIFO"
   };
 }

--- a/detail/TimeForwarder.js
+++ b/detail/TimeForwarder.js
@@ -193,6 +193,7 @@ TimeForwarder.prototype.blockSystem = function(timeToBlock) {
   if(!this.isExpiringEvents()) {
     assert(this.timeServer.targetTime.isEqualTo(this.timeServer.currentTime));
     this.timeServer.targetTime.add(blockStep);
+    this.debugLogger('simulating blocking call until ' + this.timeServer.targetTime.toNanoseconds() + 'ns');
   }
   else if(this.timeServer.targetTime.isShorterThan(this.timeServer.currentTime.extended(blockStep))) {
     throw new Error("Cannot block system during advancing for longer than requested advance time. Currently at: << " + 

--- a/detail/TimeForwarder.js
+++ b/detail/TimeForwarder.js
@@ -15,11 +15,12 @@ function delayByCycling(schedule, cycleCount, f) {
   })(f);
 }
 
-function TimeForwarder(timeServer, timerInterceptor, immediateInterceptor) {
+function TimeForwarder(timeServer, timerInterceptor, immediateInterceptor, debugLogger) {
   this.forwardingStartedSavedStack = undefined;
   this.timerInterceptor = timerInterceptor;  
   this.timeServer = timeServer;
   this.immediateInterceptor = immediateInterceptor; 
+  this.debugLogger = debugLogger;
 }
 
 TimeForwarder.prototype.prepareTimeReport = function() {
@@ -88,6 +89,7 @@ TimeForwarder.prototype.advanceTime = function(timeToForward) {
     }
 
     that.timeServer.targetTime = that.timeServer.currentTime.extended(advanceStep);
+    that.debugLogger('advancing time to ' + that.timeServer.targetTime.toNanoseconds() + 'ns');
     that.startExpiringEvents();
 	
     // that's a workaround - in certain cases I believe this might not work (pathological chains of setImmediate/process.nextTick)

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -39,6 +39,7 @@
  may require changes for the browser. Node timers are handled by the same queues as global ones (they are in fact aliases)
  - `rejectOnCallbackFailure` - a `boolean`. If `true`, all promises returned by time forwarding functions will be rejected if any of callbacks exit with an exception. In such case promises will be rejected with an array of
  objects representing failure time, delay of timeout (second argument of `setTimeout`/`setInterval`) and exception. If `false`, promises will be resolved with same argument. By default `false`, it is recommended to set it to `true`
+ - `debugLogger` - a function of one argument, a message, for logging changes in time. Pass a [debug](https://www.npmjs.com/package/debug) instance here, or `console.log`, to get output regarding time changes.
  - `timerSchedulingPolicy` - a `string`. It is a name of policy used to schedule timers that have same due time. Default value is "FIFO" (timers will expire in same order as they were set up), it is recommended to keep it this way 
  or change to "Random". Available options:
   - FIFO - timers with same due time will expire in the same order as they were set up

--- a/tests/DebugLoggingTests.js
+++ b/tests/DebugLoggingTests.js
@@ -15,7 +15,6 @@ describe('zurvan', function() {
       .then(function() {
         assert(messages.length === 1);
         assert(messages[0] === 'intercepting timers');
-      }).then(function() {
         return zurvan.releaseTimers();
       }).then(function() {
         assert(messages.length === 2);
@@ -30,10 +29,30 @@ describe('zurvan', function() {
     };
 	  return zurvan.interceptTimers({debugLogger: logger})
       .then(function() {
+        assert(messages.length === 1);
+        assert(messages[0] === 'intercepting timers');
         return zurvan.forcedReleaseTimers();
       }).then(function() {
         assert(messages.length === 2);
         assert(messages[1] === 'releasing timers (forced)');
+      });
+  });
+
+	it('logs on advancing time', function() {
+    var messages = []
+    var logger = function(message) {
+      messages.push(message);
+    };
+	  return zurvan.interceptTimers({debugLogger: logger})
+      .then(function() {
+        assert(messages.length === 2);
+        assert(messages[0] === 'intercepting timers');
+        assert(messages[1] === 'advancing time to 0ns');
+        return zurvan.advanceTime(1000);
+      }).then(function() {
+        assert(messages.length === 3);
+        assert(messages[2] === 'advancing time to 1000000000ns');
+        return zurvan.releaseTimers();
       });
   });
   });

--- a/tests/DebugLoggingTests.js
+++ b/tests/DebugLoggingTests.js
@@ -6,44 +6,49 @@ var assert = require("assert");
 
 describe('zurvan', function() {
   describe('debug logging', function() { 
-	it('logs on interceptTimers and releaseTimers', function() {
-    var messages = []
-    var logger = function(message) {
-      messages.push(message);
-    };
-	  return zurvan.interceptTimers({debugLogger: logger})
+    it('logs on interceptTimers and releaseTimers', function() {
+      var messages = []
+      var logger = function(message) {
+        messages.push(message);
+      };
+      return zurvan.interceptTimers({debugLogger: logger})
       .then(function() {
-        assert(messages.length === 1);
+        assert(messages.length === 2);
         assert(messages[0] === 'intercepting timers');
+        assert(messages[1] === 'advancing time to 0ns');
         return zurvan.releaseTimers();
       }).then(function() {
-        assert(messages.length === 2);
-        assert(messages[1] === 'releasing timers');
+        console.log(messages);
+        assert(messages.length === 4);
+        assert(messages[2] === 'releasing timers');
+        assert(messages[3] === 'advancing time to 0ns');
       });
-  });
+    });
 
-	it('logs on forcedReleaseTimers', function() {
-    var messages = []
-    var logger = function(message) {
-      messages.push(message);
-    };
-	  return zurvan.interceptTimers({debugLogger: logger})
+    it('logs on forcedReleaseTimers', function() {
+      var messages = []
+      var logger = function(message) {
+        messages.push(message);
+      };
+      return zurvan.interceptTimers({debugLogger: logger})
       .then(function() {
-        assert(messages.length === 1);
+        assert(messages.length === 2);
         assert(messages[0] === 'intercepting timers');
+        assert(messages[1] === 'advancing time to 0ns');
         return zurvan.forcedReleaseTimers();
       }).then(function() {
-        assert(messages.length === 2);
-        assert(messages[1] === 'releasing timers (forced)');
+        console.log(messages);
+        assert(messages.length === 3);
+        assert(messages[2] === 'releasing timers (forced)');
       });
-  });
+    });
 
-	it('logs on advancing time', function() {
-    var messages = []
-    var logger = function(message) {
-      messages.push(message);
-    };
-	  return zurvan.interceptTimers({debugLogger: logger})
+    it('logs on advancing time', function() {
+      var messages = []
+      var logger = function(message) {
+        messages.push(message);
+      };
+      return zurvan.interceptTimers({debugLogger: logger})
       .then(function() {
         assert(messages.length === 2);
         assert(messages[0] === 'intercepting timers');
@@ -54,6 +59,24 @@ describe('zurvan', function() {
         assert(messages[2] === 'advancing time to 1000000000ns');
         return zurvan.releaseTimers();
       });
-  });
+    });
+
+    it('logs on blockSystem', function() {
+      var messages = []
+      var logger = function(message) {
+        messages.push(message);
+      };
+      return zurvan.interceptTimers({debugLogger: logger})
+      .then(function() {
+        assert(messages.length === 2);
+        assert(messages[0] === 'intercepting timers');
+        assert(messages[1] === 'advancing time to 0ns');
+        return zurvan.blockSystem(1000);
+      }).then(function() {
+        assert(messages.length === 3);
+        assert(messages[2] === 'simulating blocking call until 1000000000ns');
+        return zurvan.releaseTimers();
+      });
+    });
   });
 });

--- a/tests/DebugLoggingTests.js
+++ b/tests/DebugLoggingTests.js
@@ -1,0 +1,40 @@
+"use strict";
+var TimeUnit = require("../TimeUnit");
+var zurvan = require("../zurvan");
+
+var assert = require("assert");
+
+describe('zurvan', function() {
+  describe('debug logging', function() { 
+	it('logs on interceptTimers and releaseTimers', function() {
+    var messages = []
+    var logger = function(message) {
+      messages.push(message);
+    };
+	  return zurvan.interceptTimers({debugLogger: logger})
+      .then(function() {
+        assert(messages.length === 1);
+        assert(messages[0] === 'intercepting timers');
+      }).then(function() {
+        return zurvan.releaseTimers();
+      }).then(function() {
+        assert(messages.length === 2);
+        assert(messages[1] === 'releasing timers');
+      });
+  });
+
+	it('logs on forcedReleaseTimers', function() {
+    var messages = []
+    var logger = function(message) {
+      messages.push(message);
+    };
+	  return zurvan.interceptTimers({debugLogger: logger})
+      .then(function() {
+        return zurvan.forcedReleaseTimers();
+      }).then(function() {
+        assert(messages.length === 2);
+        assert(messages[1] === 'releasing timers (forced)');
+      });
+  });
+  });
+});

--- a/zurvan.js
+++ b/zurvan.js
@@ -72,7 +72,11 @@ Zurvan.prototype.resetSubcomponents = function() {
   this.immediateInterceptor = new ImmediateInterceptor();
   this.allTimersInterceptor = new AllTimersInterceptor(this.timeServer);
   
-  this.timeForwarder = new TimeForwarder(this.timeServer, this.allTimersInterceptor, this.immediateInterceptor);
+  this.timeForwarder = new TimeForwarder(
+    this.timeServer,
+    this.allTimersInterceptor,
+    this.immediateInterceptor,
+    function(message) { this.config.debugLogger(message); });
   
   this.processTimerInterceptor = new ProcessTimerInterceptor(this.timeServer);
   this.dateInterceptor = new DateInterceptor(this.timeServer);

--- a/zurvan.js
+++ b/zurvan.js
@@ -80,6 +80,7 @@ Zurvan.prototype.resetSubcomponents = function() {
 
 Zurvan.prototype.interceptTimers = function(config) {
   var newConfig = Configuration.merge(config, this.globalConfig);
+  newConfig.debugLogger('intercepting timers');
 
   // this error has to be synchronous, since we do not know yet whether the system supports Promises
   var missingRuntimeDependencies = Dependencies.missingAtIntercept(newConfig);
@@ -203,9 +204,11 @@ var forcedReleaseSteps = [
 ];
 
 Zurvan.prototype.releaseTimers = function() {
+  this.config.debugLogger('releasing timers');
   return sequentialScenario(this, releaseSteps);
 };
 Zurvan.prototype.forcedReleaseTimers = function() {
+  this.config.debugLogger('releasing timers (forced)');
   return sequentialScenario(this, forcedReleaseSteps);
 };
 


### PR DESCRIPTION
I find it very useful, when reading a debug log of a test failure, to see when the time advanced and by what duration.  Fixes #46.